### PR TITLE
Add a beforePageChange event handler that allows the application an opportunity to cancel pagination

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -84,6 +84,22 @@ h3. scrollContainer
 *Default:* $(window)
 By default, scroll events are listened from the $(window) object. You can use this setting to specify a custom container, for example a div with overflow.
 
+h3. beforePageChange
+
+*Default:* empty function
+
+Event handler.  Is called when a user scrolls to another page, but before the new items are loaded.  Returning false will cancel the load;  any return value other than false will allow the pagination to proceed as normal.
+
+Parameters:
+
+|*param*|*description*|
+|curScrOffset|Current scroll offset of the page|
+|nextPageUrl|URL of the page that would be loaded if the beforePageChange does not return false|
+
+Example:
+
+bc. beforePageChange: function(scrollOffset, nextPageUrl) { console.log("The user wants to go to the next page, but they can't!"); return false; }
+
 h3. onPageChange
 
 *Default:* empty function

--- a/jquery.ias.js
+++ b/jquery.ias.js
@@ -153,6 +153,10 @@
             urlNextPage = $(opts.next).attr("href");
             if (!urlNextPage) return stop_scroll();
 
+            if (opts.beforePageChange && $.isFunction(opts.beforePageChange)) {
+              if (opts.beforePageChange(curScrOffset, urlNextPage) === false) return;
+            }
+
             paging.pushPages(curScrOffset, urlNextPage);
 
             stop_scroll();
@@ -314,6 +318,7 @@
         tresholdMargin: 0,
         history : true,
         onPageChange: function() {},
+        beforePageChange: function() {},
         onLoadItems: function() {},
         onRenderComplete: function() {},
         customLoaderProc: false


### PR DESCRIPTION
Sometimes it is necessary to temporarily disable scrolls loading new pages of content based on the state of the application.

For example, we have a case where our scrollable content is on one tab, but if the user is on another tab, the scrolls were causing new content to load anyway.

This patch adds an event handler similar to onPageChange, but that is called before the page change, that gives the application a chance to examine its current state and cancel the pagination if necessary by returning false.
