### PR TITLE
Don't show loader within table

### DIFF
--- a/jquery.ias.js
+++ b/jquery.ias.js
@@ -136,7 +136,7 @@
             treshold = el.offset().top + el.height();
 
             if (!pure)
-                treshold += opts.tresholdMargin;
+                treshold += parseInt(opts.tresholdMargin);
 
             return treshold;
         }


### PR DESCRIPTION
Hi there. Love the IAS plugin.

I'm using it to add additional data to an html table element on scroll.

In this scenario, because the show_loader function renders a div, I found it useful to check and prevent rendering that div inside the table since that would cause invalid markups and potentially some rendering issues.

I added a simple check in show_loader to render the div just after the table.
