### PR TITLE
updated demos and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Optionally add the stylesheet:
 jQuery.ias({
     container : '.listing',
     item: '.post',
-    pagination: '#content .navigation',
+    pagination: '#navigation',
     next: '.next-posts a',
     loader: '<img src="dist/images/loader.gif"/>'
 });
@@ -71,7 +71,7 @@ Enter the selector of the element that each item has. Make sure the elements are
 
 **Default:** "#pagination"
 
-Enter the selector of the element that contains your regular pagination links, like next, previous and the page numbers. This element will be hidden when IAS loads.
+Enter the selector of the element that contains your regular pagination links, like next, previous and the page numbers. This element will be hidden when IAS loads. It must be an ID or nothing past the second page can be loaded.
 
 ### `next`
 
@@ -260,7 +260,7 @@ You can integrate Google Analytics by using the onPageChange event. Here is an e
 jQuery.ias({
     container : '.listing',
     item: '.post',
-    pagination: '#content .navigation',
+    pagination: '#navigation',
     next: '.next-posts a',
     loader: '<img src="images/loader.gif"/>',
     onPageChange: function(pageNum, pageUrl, scrollOffset) {
@@ -280,7 +280,7 @@ Example on how to integrate [jQuery Masonry](http://masonry.desandro.com/).
 jQuery.ias({
     container : '.listing',
     item: '.post',
-    pagination: '#content .navigation',
+    pagination: '#navigation',
     next: '.next-posts a',
     loader: '<img src="images/loader.gif"/>',
     onLoadItems: function(items) {

--- a/demo/page1.html
+++ b/demo/page1.html
@@ -11,7 +11,7 @@
             jQuery.ias({
                 container : '.listing',
                 item: '.post',
-                pagination: '#content .navigation',
+                pagination: '#navigation',
                 next: '.next-posts a',
                 loader: '<img src="https://raw.github.com/webcreate/infinite-ajax-scroll/master/dist/images/loader.gif"/>',
                 triggerPageThreshold: 2
@@ -41,16 +41,16 @@ Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante.</p
  Donec eu libero sit amet quam egestas semper.</p>
         </div>
 
-    </div>
+    </div class="listing">
 
-    <div class="navigation">
+    <div id="navigation">
         <ul>
             <li>1</li>
             <li class="next-posts"><a href="page2.html">2</a></li>
             <li><a href="page3.html">3</a></li>
         </ul>
-    </div>
-</div>
+    </div id="navigation">
+</div id="content">
 
 </body>
 </html>

--- a/demo/page2.html
+++ b/demo/page2.html
@@ -11,7 +11,7 @@
             jQuery.ias({
                 container : '.listing',
                 item: '.post',
-                pagination: '#content .navigation',
+                pagination: '#navigation',
                 next: '.next-posts a',
                 loader: '<img src="https://raw.github.com/webcreate/infinite-ajax-scroll/master/dist/images/loader.gif"/>',
                 triggerPageThreshold: 2
@@ -51,7 +51,7 @@
 
     </div>
 
-    <div class="navigation">
+    <div id="navigation">
         <ul>
             <li class="prev-posts"><a href="page1.html">1</a></li>
             <li>2</li>

--- a/demo/page3.html
+++ b/demo/page3.html
@@ -11,7 +11,7 @@
             jQuery.ias({
                 container : '.listing',
                 item: '.post',
-                pagination: '#content .navigation',
+                pagination: '#navigation',
                 next: '.next-posts a',
                 loader: '<img src="https://raw.github.com/webcreate/infinite-ajax-scroll/master/dist/images/loader.gif"/>',
                 triggerPageThreshold: 2
@@ -60,7 +60,7 @@
 
     </div>
 
-    <div class="navigation">
+    <div id="navigation">
         <ul>
             <li class="next-posts"><a href="page1.html">1</a></li>
             <li><a href="page2.html">2</a></li>


### PR DESCRIPTION
Had problems with the demo, wouldn't scroll past page 2 with non-ID identification of next page link due to parse failure, so I added a third page, used IDs instead of classes, and documented it.
Bailed on the node/grunt testing infrastructure when I saw that copies of the demo files were used for testing instead of the actual demo files.
Thanks. It was just what I wanted, with pretty good documentation.
