### PR TITLE
Update jquery-ias.js

### DIFF
--- a/dist/jquery-ias.js
+++ b/dist/jquery-ias.js
@@ -212,7 +212,7 @@
                     $(items).fadeIn();
                 }
 
-                urlNextPage = $(opts.next, data).attr('href');
+                urlNextPage = $(opts.next).attr('href');
 
                 // update pagination
                 $(opts.pagination).replaceWith($(opts.pagination, data));


### PR DESCRIPTION
On line 215 there is:
"urlNextPage = $(opts.next, data).attr('href');"

Removed the ", data" and now the noneleft functionality works. This error was returning undefined after loading the last page, causing the stop_scroll function to be called instead of the last reset call.
