### PR TITLE
Abort loading of the page aborted request.

### DIFF
--- a/dist/jquery-ias.js
+++ b/dist/jquery-ias.js
@@ -255,34 +255,45 @@
 
             delay = delay || opts.loaderDelay;
 
-            $.get(url, null, function (data) {
-                // walk through the items on the next page
-                // and add them to the items array
-                container = $(opts.container, data).eq(0);
-                if (0 === container.length) {
-                    // incase the element is a root element (body > element),
-                    // try to filter it
-                    container = $(data).filter(opts.container).eq(0);
-                }
 
-                if (container) {
-                    container.find(opts.item).each(function () {
-                        items.push(this);
-                    });
-                }
-
-                if (onCompleteHandler) {
-                    self = this;
-                    diffTime = Date.now() - startTime;
-                    if (diffTime < delay) {
-                        setTimeout(function () {
-                            onCompleteHandler.call(self, data, items);
-                        }, delay - diffTime);
-                    } else {
-                        onCompleteHandler.call(self, data, items);
-                    }
-                }
-            }, 'html');
+			$.ajax({
+					beforeSend: function(jqXHR) {
+						$.xhrPool.abortAll();
+						$.xhrPool.push(jqXHR);
+					},
+					dataType: 'html',
+					url: url,
+					success: function(data) {
+						container = $(opts.container, data).eq(0);
+						if (0 === container.length) {
+							// incase the element is a root element (body > element),
+							// try to filter it
+							container = $(data).filter(opts.container).eq(0);
+						}
+						if (container) {
+							container.find(opts.item).each(function () {
+									items.push(this);
+								});
+						}
+						if (onCompleteHandler) {
+							self = this;
+							diffTime = Date.now() - startTime;
+							if (diffTime < delay) {
+								setTimeout(function () {
+										onCompleteHandler.call(self, data, items);
+									}, delay - diffTime);
+							} else {
+								onCompleteHandler.call(self, data, items);
+							}
+						}								
+					},
+					complete: function(jqXHR) {
+						var index = $.xhrPool.indexOf(jqXHR);
+						if (index > -1) {
+							$.xhrPool.splice(index, 1);
+						}	
+					}
+				});
         }
 
         /**
@@ -771,3 +782,13 @@
         };
     };
 })(jQuery);
+
+
+// Build xhrPool Array.
+jQuery.xhrPool = [];
+jQuery.xhrPool.abortAll = function() {
+	jQuery(this).each(function(idx, jqXHR) {
+			jqXHR.abort();
+		});
+	jQuery.xhrPool.length = 0	
+};


### PR DESCRIPTION
Changed $.get to $.ajax in loadItems function. Added xhrPool array at the bottom. jqXHR is saved as array and destroyed if another call is made during the page loading. This fixes my problem when I use infinite ajax scroll in a product filtering page which is loaded by Ajax. User can change the filter settings when the page is getting loaded so it needs to actually load the page from the last filter state aborting previous call.

This may not be the right way to deal my problem but this fixes my problem.
