### PR TITLE
Changing window load event listener to document ready due to buggy behav...

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -458,7 +458,7 @@
          */
         function init()
         {
-            $(window).load(function () {
+            $(document).ready(function () {
                 wndIsLoaded = true;
             });
         }


### PR DESCRIPTION
...ior with jQuery 2.0.3

As a result it sends the browser into a infinite scroll to top loop.

Expected behavior:
http://www.franklinclark.com/ias-scroll-fix/#/page/2

Actual behavior:
http://www.franklinclark.com/ias-scroll-bug/#/page/2
