### PR TITLE
Support for Opera Mini

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -29,8 +29,6 @@
     this.negativeMargin = options.negativeMargin;
     this.nextUrl = null;
     this.isBound = false;
-    /* Browsers that handle JavaScript via proxy servers don't support the scroll event */
-    this.hasScrollEvent = ('onscroll' in window ? true : false);
     this.listeners = {
       next:     new IASCallbacks(),
       load:     new IASCallbacks(),
@@ -329,6 +327,9 @@
   IAS.prototype.initialize = function() {
     var currentScrollOffset = this.getCurrentScrollOffset(this.$scrollContainer),
         scrollThreshold = this.getScrollThreshold();
+
+    /* Browsers that handle JavaScript via proxy servers don't support the scroll event */
+    this.hasScrollEvent = ('onscroll' in window ? true : false);
 
     this.hidePagination();
     this.bind();

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -29,6 +29,8 @@
     this.negativeMargin = options.negativeMargin;
     this.nextUrl = null;
     this.isBound = false;
+    /* Browsers that handle JavaScript via proxy servers don't support the scroll event */
+    this.hasScrollEvent = ('onscroll' in window ? true : false);
     this.listeners = {
       next:     new IASCallbacks(),
       load:     new IASCallbacks(),
@@ -242,7 +244,8 @@
      * Hides the pagination
      */
     this.hidePagination = function() {
-      if (this.paginationSelector) {
+      /* If the browser doesn't support the scroll event, don't hide the pagination */
+      if (this.paginationSelector && this.hasScrollEvent) {
         $(this.paginationSelector, this.$container).hide();
       }
     };


### PR DESCRIPTION
Opera Mini and some other mobile browsers use servers to process JavaScript, then send the result back to the device. Devices like these don't support the Scroll event, so I added a check to the constructor that verifies the browser supports 'onscroll'. If it doesn't, we won't hide the manual pagination link. This allows the plugin to fail gracefully on low-power mobile devices.

I've only been able to test this with Opera Mini for iOS, so verification that it works on other devices/browsers would be appreciated.