### PR TITLE
Improve compatibility support when Prototype is used along with jQuery

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -126,7 +126,7 @@ IASCallbacks.prototype = {
    * @returns {object|void}
    */
   fireWith: function (context, args) {
-    var deferred = $.Deferred();
+    var deferred = jQuery.Deferred();
 
     if (this.isDisabled) {
       return deferred.reject();

--- a/src/extension/history.js
+++ b/src/extension/history.js
@@ -9,7 +9,7 @@
  */
 
 var IASHistoryExtension = function (options) {
-  options = $.extend({}, this.defaults, options);
+  options = jQuery.extend({}, this.defaults, options);
 
   this.ias = null;
   this.prevSelector = options.prev;
@@ -64,7 +64,7 @@ var IASHistoryExtension = function (options) {
     }
 
     // always take the last matching item
-    return $(this.prevSelector, container).last().attr('href');
+    return jQuery(this.prevSelector, container).last().attr('href');
   };
 
   /**
@@ -102,11 +102,11 @@ var IASHistoryExtension = function (options) {
 
     ias.fire('render', [items]);
 
-    $(items).hide(); // at first, hide it so we can fade it in later
+    jQuery(items).hide(); // at first, hide it so we can fade it in later
 
     $firstItem.before(items);
 
-    $(items).fadeIn(400, function () {
+    jQuery(items).fadeIn(400, function () {
       if (++count < items.length) {
         return;
       }
@@ -150,8 +150,8 @@ IASHistoryExtension.prototype.initialize = function (ias) {
 IASHistoryExtension.prototype.bind = function (ias) {
   var self = this;
 
-  ias.on('pageChange', $.proxy(this.onPageChange, this));
-  ias.on('scroll', $.proxy(this.onScroll, this));
+  ias.on('pageChange', jQuery.proxy(this.onPageChange, this));
+  ias.on('scroll', jQuery.proxy(this.onScroll, this));
   ias.on('ready', function () {
     var currentScrollOffset = ias.getCurrentScrollOffset(ias.$scrollContainer),
         firstItemScrollThreshold = self.getScrollThresholdFirstItem();

--- a/src/extension/noneleft.js
+++ b/src/extension/noneleft.js
@@ -9,7 +9,7 @@
  */
 
 var IASNoneLeftExtension = function(options) {
-  options = $.extend({}, this.defaults, options);
+  options = jQuery.extend({}, this.defaults, options);
 
   this.ias = null;
   this.uid = (new Date()).getTime();
@@ -19,7 +19,7 @@ var IASNoneLeftExtension = function(options) {
    * Shows none left message
    */
   this.showNoneLeft = function() {
-    var $element = $(this.html).attr('id', 'ias_noneleft_' + this.uid),
+    var $element = jQuery(this.html).attr('id', 'ias_noneleft_' + this.uid),
         $lastItem = this.ias.getLastItem();
 
     $lastItem.after($element);
@@ -35,7 +35,7 @@ var IASNoneLeftExtension = function(options) {
 IASNoneLeftExtension.prototype.bind = function(ias) {
   this.ias = ias;
 
-  ias.on('noneLeft', $.proxy(this.showNoneLeft, this));
+  ias.on('noneLeft', jQuery.proxy(this.showNoneLeft, this));
 };
 
 /**

--- a/src/extension/paging.js
+++ b/src/extension/paging.js
@@ -111,11 +111,11 @@ IASPagingExtension.prototype.initialize = function(ias) {
  */
 IASPagingExtension.prototype.bind = function(ias) {
   try {
-    ias.on('prev', $.proxy(this.onPrev, this), this.priority);
+    ias.on('prev', jQuery.proxy(this.onPrev, this), this.priority);
   } catch (exception) {}
 
-  ias.on('next', $.proxy(this.onNext, this), this.priority);
-  ias.on('scroll', $.proxy(this.onScroll, this), this.priority);
+  ias.on('next', jQuery.proxy(this.onNext, this), this.priority);
+  ias.on('scroll', jQuery.proxy(this.onScroll, this), this.priority);
 };
 
 /**

--- a/src/extension/spinner.js
+++ b/src/extension/spinner.js
@@ -9,7 +9,7 @@
  */
 
 var IASSpinnerExtension = function(options) {
-  options = $.extend({}, this.defaults, options);
+  options = jQuery.extend({}, this.defaults, options);
 
   this.ias = null;
   this.uid = new Date().getTime();
@@ -51,7 +51,7 @@ var IASSpinnerExtension = function(options) {
    * @returns {jQuery|boolean}
    */
   this.getSpinner = function() {
-    var $spinner = $('#ias_spinner_' + this.uid);
+    var $spinner = jQuery('#ias_spinner_' + this.uid);
 
     if ($spinner.size() > 0) {
       return $spinner;
@@ -64,7 +64,7 @@ var IASSpinnerExtension = function(options) {
    * @returns {boolean}
    */
   this.hasSpinner = function() {
-    var $spinner = $('#ias_spinner_' + this.uid);
+    var $spinner = jQuery('#ias_spinner_' + this.uid);
 
     return ($spinner.size() > 0);
   };
@@ -73,7 +73,7 @@ var IASSpinnerExtension = function(options) {
    * @returns {jQuery}
    */
   this.createSpinner = function() {
-    var $spinner = $(this.html).attr('id', 'ias_spinner_' + this.uid);
+    var $spinner = jQuery(this.html).attr('id', 'ias_spinner_' + this.uid);
 
     $spinner.hide();
 
@@ -89,13 +89,13 @@ var IASSpinnerExtension = function(options) {
 IASSpinnerExtension.prototype.bind = function(ias) {
   this.ias = ias;
 
-  ias.on('next', $.proxy(this.showSpinner, this));
+  ias.on('next', jQuery.proxy(this.showSpinner, this));
 
   try {
-    ias.on('prev', $.proxy(this.showSpinnerBefore, this));
+    ias.on('prev', jQuery.proxy(this.showSpinnerBefore, this));
   } catch (exception) {}
 
-  ias.on('render', $.proxy(this.removeSpinner, this));
+  ias.on('render', jQuery.proxy(this.removeSpinner, this));
 };
 
 /**

--- a/src/extension/trigger.js
+++ b/src/extension/trigger.js
@@ -9,7 +9,7 @@
  */
 
 var IASTriggerExtension = function(options) {
-  options = $.extend({}, this.defaults, options);
+  options = jQuery.extend({}, this.defaults, options);
 
   this.ias = null;
   this.html = (options.html).replace('{text}', options.text);
@@ -68,10 +68,10 @@ var IASTriggerExtension = function(options) {
         $trigger;
 
     html = html || this.html;
-    $trigger = $(html).attr('id', 'ias_trigger_' + uid);
+    $trigger = jQuery(html).attr('id', 'ias_trigger_' + uid);
 
     $trigger.hide();
-    $trigger.on('click', $.proxy(clickCallback, this));
+    $trigger.on('click', jQuery.proxy(clickCallback, this));
 
     return $trigger;
   };
@@ -89,10 +89,10 @@ IASTriggerExtension.prototype.bind = function(ias) {
   this.ias = ias;
 
   try {
-    ias.on('prev', $.proxy(this.showTriggerPrev, this), this.priority);
+    ias.on('prev', jQuery.proxy(this.showTriggerPrev, this), this.priority);
   } catch (exception) {}
 
-  ias.on('next', $.proxy(this.showTriggerNext, this), this.priority);
+  ias.on('next', jQuery.proxy(this.showTriggerNext, this), this.priority);
   ias.on('rendered', function () { self.enabled = true; }, this.priority);
 };
 


### PR DESCRIPTION
Usage of $ causes issue when Prototype is used along with jQuery (even with usage of jQuery.noConflict()).

By replacing $ by jQuery, we are safe! :)
