### PR TITLE
Implementation of a 'reload' method (extremely useful to rebind an updated DOM)

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -347,6 +347,33 @@
   };
 
   /**
+   * Reload IAS
+   *
+   * Note: Useful when the items container DOM is modified by external actions
+   *
+   * @public
+   */
+  IAS.prototype.reload = function() {
+    // IMPORTANT: Redefine items container to get correct item in getLastItem method
+    this.$itemsContainer = $(this.itemsContainerSelector);
+
+    var currentScrollOffset = this.getCurrentScrollOffset(this.$scrollContainer),
+        scrollThreshold = this.getScrollThreshold();
+
+    this.hidePagination();
+    this.bind();
+
+    this.nextUrl = this.getNextUrl();
+
+    // start loading next page if content is shorter than page fold
+    if (currentScrollOffset >= scrollThreshold) {
+        this.next();
+    }
+
+    return this;
+  };
+
+  /**
    * Binds IAS to DOM events
    *
    * @public


### PR DESCRIPTION
Sometimes, DOM can be updated by external actions/scripts (especially the items container).

It results that the infinite scroll is not working anymore, due to an obsolete binded DOM in getLastItem() method. It results the following incorrect calculation in getScrollThreshold() method:

$lastElement.offset().top will always equal 0.
$lastElement.height() will always equal 0.
currentScrollOffset >= scrollThreshold will never happen in scrollHandler() method.

By using the new reload() method after a DOM change, we redefine items container and calculations are back to normal.
