### PR TITLE
Maintain history state object when changing pages

### DIFF
--- a/src/extension/history.js
+++ b/src/extension/history.js
@@ -30,6 +30,8 @@ var IASHistoryExtension = function (options) {
     if (!window.history || !window.history.replaceState) {
       return;
     }
+    
+    state = history.state;
 
     history.replaceState(state, document.title, url);
   };


### PR DESCRIPTION
This is required for history-management libraries like jquery-pjax which uses the state object to load pages via AJAX.
