### PR TITLE
Add option to disable caching Ajax responses.

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -26,6 +26,7 @@
     this.$container = (window === $element.get(0) ? $(document) : $element);
     this.defaultDelay = options.delay;
     this.negativeMargin = options.negativeMargin;
+    this.cacheAjaxResults = options.cacheAjaxResults;
     this.nextUrl = null;
     this.isBound = false;
     this.isPaused = false;
@@ -185,31 +186,37 @@
 
       self.fire('load', [loadEvent]);
 
-      return $.get(loadEvent.url, null, $.proxy(function(data) {
-        $itemContainer = $(this.itemsContainerSelector, data).eq(0);
-        if (0 === $itemContainer.length) {
-          $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
-        }
-
-        if ($itemContainer) {
-          $itemContainer.find(this.itemSelector).each(function() {
-            items.push(this);
-          });
-        }
-
-        self.fire('loaded', [data, items]);
-
-        if (callback) {
-          timeDiff = +new Date() - timeStart;
-          if (timeDiff < delay) {
-            setTimeout(function() {
-              callback.call(self, data, items);
-            }, delay - timeDiff);
-          } else {
-            callback.call(self, data, items);
+      return $.ajax({
+        url: loadEvent.url,
+        data: null,
+        success: $.proxy(function(data) {
+          $itemContainer = $(this.itemsContainerSelector, data).eq(0);
+          if (0 === $itemContainer.length) {
+            $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
           }
-        }
-      }, self), 'html');
+
+          if ($itemContainer) {
+            $itemContainer.find(this.itemSelector).each(function() {
+              items.push(this);
+            });
+          }
+
+          self.fire('loaded', [data, items]);
+
+          if (callback) {
+            timeDiff = +new Date() - timeStart;
+            if (timeDiff < delay) {
+              setTimeout(function() {
+                callback.call(self, data, items);
+              }, delay - timeDiff);
+            } else {
+              callback.call(self, data, items);
+            }
+          }
+        }, self),
+        dataType: 'html',
+        cache: this.cacheAjaxResults
+      });
     };
 
     /**
@@ -627,6 +634,7 @@
     next: '.next',
     pagination: false,
     delay: 600,
-    negativeMargin: 10
+    negativeMargin: 10,
+    cacheAjaxResults: true
   };
 })(jQuery);

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -26,7 +26,6 @@
     this.$container = (window === $element.get(0) ? $(document) : $element);
     this.defaultDelay = options.delay;
     this.negativeMargin = options.negativeMargin;
-    this.cacheAjaxResults = options.cacheAjaxResults;
     this.nextUrl = null;
     this.isBound = false;
     this.isPaused = false;
@@ -187,37 +186,31 @@
 
       self.fire('load', [loadEvent]);
 
-      return $.ajax({
-        url: loadEvent.url,
-        data: null,
-        success: $.proxy(function(data) {
-          $itemContainer = $(this.itemsContainerSelector, data).eq(0);
-          if (0 === $itemContainer.length) {
-            $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
-          }
+      return $.get(loadEvent.url, null, $.proxy(function(data) {
+        $itemContainer = $(this.itemsContainerSelector, data).eq(0);
+        if (0 === $itemContainer.length) {
+          $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
+        }
 
-          if ($itemContainer) {
-            $itemContainer.find(this.itemSelector).each(function() {
-              items.push(this);
-            });
-          }
+        if ($itemContainer) {
+          $itemContainer.find(this.itemSelector).each(function() {
+            items.push(this);
+          });
+        }
 
-          self.fire('loaded', [data, items]);
+        self.fire('loaded', [data, items]);
 
-          if (callback) {
-            timeDiff = +new Date() - timeStart;
-            if (timeDiff < delay) {
-              setTimeout(function() {
-                callback.call(self, data, items);
-              }, delay - timeDiff);
-            } else {
+        if (callback) {
+          timeDiff = +new Date() - timeStart;
+          if (timeDiff < delay) {
+            setTimeout(function() {
               callback.call(self, data, items);
-            }
+            }, delay - timeDiff);
+          } else {
+            callback.call(self, data, items);
           }
-        }, self),
-        dataType: 'html',
-        cache: this.cacheAjaxResults
-      });
+        }
+      }, self), 'html');
     };
 
     /**
@@ -659,7 +652,6 @@
     next: '.next',
     pagination: false,
     delay: 600,
-    negativeMargin: 10,
-    cacheAjaxResults: true
+    negativeMargin: 10
   };
 })(jQuery);

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -26,6 +26,7 @@
     this.$container = (window === $element.get(0) ? $(document) : $element);
     this.defaultDelay = options.delay;
     this.negativeMargin = options.negativeMargin;
+    this.cacheAjaxResults = options.cacheAjaxResults;
     this.nextUrl = null;
     this.isBound = false;
     this.isPaused = false;
@@ -186,31 +187,37 @@
 
       self.fire('load', [loadEvent]);
 
-      return $.get(loadEvent.url, null, $.proxy(function(data) {
-        $itemContainer = $(this.itemsContainerSelector, data).eq(0);
-        if (0 === $itemContainer.length) {
-          $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
-        }
-
-        if ($itemContainer) {
-          $itemContainer.find(this.itemSelector).each(function() {
-            items.push(this);
-          });
-        }
-
-        self.fire('loaded', [data, items]);
-
-        if (callback) {
-          timeDiff = +new Date() - timeStart;
-          if (timeDiff < delay) {
-            setTimeout(function() {
-              callback.call(self, data, items);
-            }, delay - timeDiff);
-          } else {
-            callback.call(self, data, items);
+      return $.ajax({
+        url: loadEvent.url,
+        data: null,
+        success: $.proxy(function(data) {
+          $itemContainer = $(this.itemsContainerSelector, data).eq(0);
+          if (0 === $itemContainer.length) {
+            $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
           }
-        }
-      }, self), 'html');
+
+          if ($itemContainer) {
+            $itemContainer.find(this.itemSelector).each(function() {
+              items.push(this);
+            });
+          }
+
+          self.fire('loaded', [data, items]);
+
+          if (callback) {
+            timeDiff = +new Date() - timeStart;
+            if (timeDiff < delay) {
+              setTimeout(function() {
+                callback.call(self, data, items);
+              }, delay - timeDiff);
+            } else {
+              callback.call(self, data, items);
+            }
+          }
+        }, self),
+        dataType: 'html',
+        cache: this.cacheAjaxResults
+      });
     };
 
     /**
@@ -652,6 +659,7 @@
     next: '.next',
     pagination: false,
     delay: 600,
-    negativeMargin: 10
+    negativeMargin: 10,
+    cacheAjaxResults: true
   };
 })(jQuery);

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -51,7 +51,7 @@
      * @private
      */
     this.scrollHandler = function() {
-      // the throttle method can call the scrollHandler even thought we have called unbind()
+      // the throttle method can call the scrollHandler even though we have called unbind()
       if (!this.isBound || this.isPaused) {
         return;
       }
@@ -252,7 +252,7 @@
           }
         });
       });
-      
+
       promise.fail(function() {
         if (callback) {
           callback();
@@ -557,6 +557,9 @@
           self.nextUrl = self.getNextUrl(data);
 
           self.resume();
+
+          // The user may have scrolled further while we were paused
+          self.scrollHandler();
         });
       });
     });


### PR DESCRIPTION
Some older web browsers (e.g., IE 8) incorrectly cache Ajax responses. This patch changes the .get() call to .ajax(), which allows us to pass a parameter to disable caching the response. A new option, cacheAjaxResults, has been added to IAS. It defaults to 'true' to mimic the current behavior (browsers use their own logic to figure out whether the response should be fetched from cache or from the server), but can be set to 'false' to force browsers to always fetch URLs from the server. This patch allows IE 8 to work with IAS.

Defaulting 'cacheAjaxResults' to false might be a good idea, but I didn't want to change the default behavior for users to want the caching and don't care about IE 8 support.
