### PR TITLE
Feature/render call callback

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -244,6 +244,12 @@
           }
         });
       });
+      
+      promise.fail(function() {
+        if (callback) {
+          callback();
+        }
+      });
     };
 
     /**

--- a/test/04-paging-extension-test.js
+++ b/test/04-paging-extension-test.js
@@ -44,4 +44,24 @@ describe("IAS", function () {
 
     return deferred.promise;
   });
+
+  it("callbacks should be called when render returns false", function() {
+    var deferred = when.defer();
+    var spy1 = this.spy();
+
+    jQuery.ias().on('render', function() { spy1(); return false; });
+    // If the user uses their own render function (which returns false), then IAS
+    // doesn't call other render callbacks such as the one that sets the next URL
+    // This is tested by adding our own render callback and then adding checks to
+    // confirm the render callback actually did run and the nextUrl has been updated.
+    scrollDown().then(function() {
+      wait(2000).then(function() {
+        expect(spy1).toHaveBeenCalledOnce();
+        buster.assert.contains(jQuery.ias().nextUrl, "page3.html");
+
+        deferred.resolve();
+      })
+    })
+    return deferred.promise;
+  });
 });


### PR DESCRIPTION
Issue #198 

Add functionality to IAS to call the callback, even if a custom render event handler returned false.  Also add a test to ensure the callback is called.  The test ensures the callback to determine the nextUrl has been updated when a render event handler returns false.