### PR TITLE
Use the loadEvent object to provide arbitrary $.get settings

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -24,11 +24,18 @@ The load event object contains the following properties.
 |-----------|---------------|-------------------------|
 | event.url | string        | url that will be loaded |
 
-Using this event it is possible to change the requested url. This can be useful to append an arbitrary parameter to the requested url so the server can handle the request differently. For example to optimize the returned html by stripping everything outside the container element (header, footer, etc.).
+Using this event it is possible to change the requested url. This can be useful to append an arbitrary parameter to the requested url so the server can handle the request differently. For example to optimize the returned url by stripping everything outside the container element (header, footer, etc.). Because it is used as the settings object in $.get, you can also use this for more exotic configuration.
 
 ```javascript
 ias.on('load', function(event) {
     event.url = event.url + "?ajax=1";
+    // alternatively...
+    event.data = { ajax: 1 };
+
+    // And as a more exotic example, timeout and HTTP auth
+    event.timeout = 7000; //ms
+    event.username = 'shirley';
+    event.password = 'temple';
 })
 ```
 

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -182,12 +182,13 @@
       delay = delay || this.defaultDelay;
 
       var loadEvent = {
-        url: url
+        url: url,
+        dataType: 'html'
       };
 
       self.fire('load', [loadEvent]);
 
-      this.jsXhr = $.get(loadEvent.url, null, $.proxy(function(data) {
+      function xhrDoneCallback(data) {
         $itemContainer = $(this.itemsContainerSelector, data).eq(0);
         if (0 === $itemContainer.length) {
           $itemContainer = $(data).filter(this.itemsContainerSelector).eq(0);
@@ -211,7 +212,9 @@
             callback.call(self, data, items);
           }
         }
-      }, self), 'html');
+      }
+      this.jsXhr = $.get(loadEvent)
+        .done($.proxy(xhrDoneCallback, self));
 
       return this.jsXhr;
     };

--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -213,7 +213,7 @@
           }
         }
       }
-      this.jsXhr = $.get(loadEvent)
+      this.jsXhr = $.ajax(loadEvent)
         .done($.proxy(xhrDoneCallback, self));
 
       return this.jsXhr;


### PR DESCRIPTION
The jQuery AJAX API is pretty powerful. Rather than trying to wrap all of its abilities, for questionable gain, we can just use the load event object as the settings parameter. This lets downstream users override arbitrary settings, like `headers` or `cache` or `timeout`.

The downside is if people are storing funky, non-url things in the load event, this will break their use case. But it's kind of a weird thing to do in the current IAS interface, so we probably don't have to be too paranoid about backwards compatibility. For people who only use event.url, or don't use the event object at all, they won't even know anything changed.
