### PR TITLE
Tweaked when noneLeft event is fired

### DIFF
--- a/src/jquery-ias.js
+++ b/src/jquery-ias.js
@@ -552,16 +552,11 @@
     var url = this.nextUrl,
         self = this;
 
-    this.pause();
-
     if (!url) {
-      this.fire('noneLeft', [this.getLastItem()]);
-      this.listeners['noneLeft'].disable(); // disable it so it only fires once
-
-      self.resume();
-
       return false;
     }
+
+    this.pause();
 
     var promise = this.fire('next', [url]);
 
@@ -569,6 +564,11 @@
       self.load(url, function(data, items) {
         self.render(items, function() {
           self.nextUrl = self.getNextUrl(data);
+
+          if (!self.nextUrl) {
+            self.fire('noneLeft', [self.getLastItem()]);
+            self.listeners['noneLeft'].disable(); // disable it so it only fires once
+          }
 
           self.resume();
         });

--- a/test/02-listeners-test.js
+++ b/test/02-listeners-test.js
@@ -179,16 +179,9 @@ describe("IAS", function () {
         // scroll to page 3
         scrollDown().then(function() {
           wait(1500).then(function() {
-            expect(spy1).not.toHaveBeenCalled();
+            expect(spy1).toHaveBeenCalledOnce();
 
-            // now on the final page, scroll down, and expect to have been called
-            scrollDown().then(function() {
-              wait(1500).then(function() {
-                expect(spy1).toHaveBeenCalledOnce();
-
-                deferred.resolve();
-              });
-            });
+            deferred.resolve();
           });
         });
       });


### PR DESCRIPTION
The noneLeft event was fired on the next `next` call. It seems more logical to fire it after the last page has rendered (right at the moment we found out there is no more page to load).