### PR TITLE
Fix scope of variable in case of multi instance

### DIFF
--- a/src/next-handler.js
+++ b/src/next-handler.js
@@ -1,12 +1,13 @@
 import $ from 'tealight';
 
-let lastResponse = document;
-let nextUrl;
-
 export function nextHandler(pageIndex) {
+  if (!this.lastResponse) {
+    this.lastResponse = document;
+  }
+  let nextUrl;
   let ias = this;
 
-  let nextEl = $(ias.options.next, lastResponse)[0];
+  let nextEl = $(ias.options.next, this.lastResponse)[0];
 
   if (!nextEl) {
     return;
@@ -16,9 +17,9 @@ export function nextHandler(pageIndex) {
 
   return ias.load(nextUrl)
       .then((data) => {
-        lastResponse = data.xhr.response;
+        this.lastResponse = data.xhr.response;
 
-        let nextEl = $(ias.options.next, lastResponse)[0];
+        let nextEl = $(ias.options.next, this.lastResponse)[0];
 
         return ias.append(data.items)
             .then(() => {


### PR DESCRIPTION
In case of multiple instance of Library (for example more than one overflow div), the nextUrl called was from the last response, it does not matter if it comes from the other scroll div.